### PR TITLE
 [FIX] Establish basic compatibility for TYPO3 v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "support": {
         "issues": "https://github.com/extcode/tcpdf/issues"
     },
+    "version": "4.0.0",
     "autoload": {
         "psr-4": {
             "Extcode\\TCPDF\\": "Classes"
@@ -56,7 +57,7 @@
     },
     "require": {
         "php": ">=7.2.0 <7.5",
-        "typo3/cms-core": "^10.4"
+        "typo3/cms-core": "^11.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,10 +17,10 @@ $EM_CONF['tcpdf'] = [
     'modify_tables' => '',
     'clearCacheOnLoad' => 0,
     'lockType' => '',
-    'version' => '3.0.1',
+    'version' => '4.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-10.4.99'
+            'typo3' => '11.5.0-11.5.99'
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
I've done some basic stuff to make this extension usable with TYPO3 v11.5 and EXT:cart v.8.2.0.
(I had to add a version to composer.json, otherwise I could't use it.)

Testet with:

PayPal sandbox
PHP 7.4.
TYPO3 11.5.6
EXT:cart 8.2.0
EXT:cart_products 4.0.3